### PR TITLE
Fix having to call refreshResources for proper model loading

### DIFF
--- a/src/main/java/net/smileycorp/dynaores/client/ClientProxy.java
+++ b/src/main/java/net/smileycorp/dynaores/client/ClientProxy.java
@@ -25,7 +25,6 @@ public class ClientProxy extends CommonProxy {
         DynaOresLogger.logInfo("Registering models");
         ModelLoaderRegistry.registerLoader(OreModelLoader.INSTANCE);
         for (OreEntry entry : OreHandler.INSTANCE.getOres()) {
-            System.out.println("ORETEST itemmodel " + entry.getItem().getRegistryName());
             ModelResourceLocation itemLoc = new ModelResourceLocation(Constants.locStr(entry.getName() + ".raw_ore"));
             ModelLoader.setCustomModelResourceLocation(entry.getItem(), 0, itemLoc);
             if (entry.getBlock() != null) {

--- a/src/main/java/net/smileycorp/dynaores/client/ClientProxy.java
+++ b/src/main/java/net/smileycorp/dynaores/client/ClientProxy.java
@@ -1,17 +1,14 @@
 package net.smileycorp.dynaores.client;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ItemModelMesher;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.ItemColors;
 import net.minecraft.item.Item;
+import net.minecraftforge.client.event.ColorHandlerEvent;
+import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
-import net.minecraftforge.client.resource.VanillaResourceType;
-import net.minecraftforge.fml.client.FMLClientHandler;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.smileycorp.dynaores.common.CommonProxy;
@@ -22,36 +19,43 @@ import net.smileycorp.dynaores.common.data.OreHandler;
 
 public class ClientProxy extends CommonProxy {
     
-    @Override
-    public void postInit(FMLPostInitializationEvent event) {
-        super.postInit(event);
-        Minecraft mc = Minecraft.getMinecraft();
+    @SubscribeEvent
+    public void onModelRegister(ModelRegistryEvent event) {
         //register ore models
         DynaOresLogger.logInfo("Registering models");
         ModelLoaderRegistry.registerLoader(OreModelLoader.INSTANCE);
-        ItemModelMesher mesher = mc.getRenderItem().getItemModelMesher();
-        ItemColors itemColours = mc.getItemColors();
-        BlockColors blockColors = mc.getBlockColors();
         for (OreEntry entry : OreHandler.INSTANCE.getOres()) {
+            System.out.println("ORETEST itemmodel " + entry.getItem().getRegistryName());
             ModelResourceLocation itemLoc = new ModelResourceLocation(Constants.locStr(entry.getName() + ".raw_ore"));
             ModelLoader.setCustomModelResourceLocation(entry.getItem(), 0, itemLoc);
-            //have to manually copy entries to the model mesher because we register our model definitions too late for the game to automatically do it
-            mesher.register(entry.getItem(), 0, itemLoc);
-            itemColours.registerItemColorHandler(OreModelLoader.INSTANCE::getColour, entry.getItem());
             if (entry.getBlock() != null) {
                 ModelResourceLocation blockLoc = new ModelResourceLocation(Constants.locStr(entry.getName() + "_block.raw_ore"));
                 ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(entry.getBlock()), 0, blockLoc);
                 StateMapperOreBlock mapper = new StateMapperOreBlock(blockLoc);
                 ModelLoader.setCustomStateMapper(entry.getBlock(), mapper);
-                mc.getBlockRendererDispatcher().getBlockModelShapes().registerBlockWithStateMapper(entry.getBlock(), mapper);
-                //have to manually copy entries to the model mesher because we register our model definitions too late for the game to automatically do it
-                mesher.register(Item.getItemFromBlock(entry.getBlock()), 0, blockLoc);
-                itemColours.registerItemColorHandler(OreModelLoader.INSTANCE::getColour, entry.getBlock());
+            }
+        }
+    }
+    
+    @SubscribeEvent
+    public void onBlockColorRegister(ColorHandlerEvent.Block event) {
+        BlockColors blockColors = event.getBlockColors();
+        for (OreEntry entry : OreHandler.INSTANCE.getOres()) {
+            if (entry.getBlock() != null) {
                 blockColors.registerBlockColorHandler(OreModelLoader.INSTANCE::getColour, entry.getBlock());
             }
         }
-        //refresh textures and models
-        FMLClientHandler.instance().refreshResources(VanillaResourceType.TEXTURES, VanillaResourceType.MODELS);
+    }
+    
+    @SubscribeEvent
+    public void onItemColorRegister(ColorHandlerEvent.Item event) {
+        ItemColors itemColours = event.getItemColors();
+        for (OreEntry entry : OreHandler.INSTANCE.getOres()) {
+            itemColours.registerItemColorHandler(OreModelLoader.INSTANCE::getColour, entry.getItem());
+            if (entry.getBlock() != null) {
+                itemColours.registerItemColorHandler(OreModelLoader.INSTANCE::getColour, entry.getBlock());
+            }
+        }
     }
     
     @SubscribeEvent(priority = EventPriority.LOW)

--- a/src/main/java/net/smileycorp/dynaores/common/CommonProxy.java
+++ b/src/main/java/net/smileycorp/dynaores/common/CommonProxy.java
@@ -5,12 +5,9 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.world.BlockEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -32,12 +29,6 @@ public class CommonProxy {
         ConfigHandler.syncConfig(event);
         MinecraftForge.EVENT_BUS.register(this);
         OreHandler.INSTANCE.registerConfigOres();
-    }
-    
-    public void postInit(FMLPostInitializationEvent event) {}
-    
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public void registerRecipes(RegistryEvent.Register<IRecipe> event) {
         OreHandler.INSTANCE.tryRegister("oreCoal", new ItemStack(Blocks.COAL_ORE));
         OreHandler.INSTANCE.tryRegister("oreIron", new ItemStack(Blocks.IRON_ORE));
         OreHandler.INSTANCE.tryRegister("oreGold", new ItemStack(Blocks.GOLD_ORE));

--- a/src/main/java/net/smileycorp/dynaores/common/DynaOres.java
+++ b/src/main/java/net/smileycorp/dynaores/common/DynaOres.java
@@ -5,7 +5,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.smileycorp.dynaores.common.network.PacketHandler;
@@ -33,11 +32,6 @@ public class DynaOres {
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event){
         PROXY.preInit(event);
-    }
-    
-    @Mod.EventHandler
-    public void postInit(FMLPostInitializationEvent event){
-        PROXY.postInit(event);
     }
     
     @Mod.EventHandler


### PR DESCRIPTION
Reworked client-side model/texture handling to use events to avoid having to call refreshResources which incurs significant load time delays.
Only non-client change is registering vanilla raw ore dictionary entries on preInit rather than RegistryEvent.Register<IRecipe> as models are registered prior to recipes.